### PR TITLE
Revert SafePickler changes

### DIFF
--- a/Code/benchmark/jvm/src/main/scala/shipreq/benchmark/SerialisationBinaryEventsBM.scala
+++ b/Code/benchmark/jvm/src/main/scala/shipreq/benchmark/SerialisationBinaryEventsBM.scala
@@ -8,14 +8,10 @@ import shipreq.webapp.sampledata.SampleData
 
 object SerialisationBinaryEventsBM {
   import boopickle.DefaultBasic._
-  import shipreq.webapp.base.protocol.binary.SafePickler
-  import shipreq.webapp.base.protocol.Version
+  import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
   import shipreq.webapp.member.project.protocol.binary.Latest._
 
-  val binCodec = {
-    val p = implicitly[Pickler[Vector[Event]]]
-    SafePickler.of(Version.v1(0), _ => p).withMagicNumbers(123, 456)
-  }
+  val binCodec = implicitly[Pickler[Vector[Event]]].asV1(0).withMagicNumbers(123, 456)
 }
 
 @State(Scope.Benchmark)

--- a/Code/doc/codec-evolution.md
+++ b/Code/doc/codec-evolution.md
@@ -25,6 +25,11 @@ There are different types:
 How to evolve binary codecs
 ===========================
 
+* Per-pickler backwards-compatibility
+  * Add `writeVersion(v)` to the beginning of the `pickle` method
+  * Add `readByVersion(v)` to the beginning of the `unpickle` method and write separate unpicklers depending on the
+    version
+
 * Create an object called `RevX` where `X` is the new point version.
   eg. create `.binary.v1.Rev3` for v1.3
 

--- a/Code/webapp-base-test/shared/src/main/scala/shipreq/webapp/base/test/BinaryTestUtil.scala
+++ b/Code/webapp-base-test/shared/src/main/scala/shipreq/webapp/base/test/BinaryTestUtil.scala
@@ -5,8 +5,8 @@ import cats.Eq
 import nyaya.gen.Gen
 import shipreq.base.test.BaseTestUtil._
 import shipreq.base.util.BinaryData
-import shipreq.webapp.base.protocol.Version
 import shipreq.webapp.base.protocol.binary.SafePickler
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 import sourcecode.Line
 
 object BinaryTestUtil {
@@ -143,17 +143,17 @@ object BinaryTestUtil {
   // Pickler testing
 
   def assertRoundTripP[A](a: A)(implicit p: Pickler[A], e: Eq[A], l: Line): Unit = {
-    val sp = SafePickler.of(Version.v1(0), _ => p)
+    val sp = p.asV1(0)
     assertDecodeOk(sp)(sp.encode(a), a)
   }
 
   def propTestRoundTripP[A](g: Gen[A])(implicit p: Pickler[A], e: Eq[A], l: Line): Unit = {
-    val sp = SafePickler.of(Version.v1(0), _ => p)
+    val sp = p.asV1(0)
     g.samples().take(propTestSize).foreach(assertRoundTrip(sp)(_))
   }
 
   def assertRoundTripsP[A](as: Iterable[A])(implicit p: Pickler[A], e: Eq[A], l: Line): Unit = {
-    val sp = SafePickler.of(Version.v1(0), _ => p)
+    val sp = p.asV1(0)
     var i = 0
     for (a <- as) {
       i += 1

--- a/Code/webapp-base-test/shared/src/test/scala/shipreq/webapp/base/protocol/SafePicklerTest.scala
+++ b/Code/webapp-base-test/shared/src/test/scala/shipreq/webapp/base/protocol/SafePicklerTest.scala
@@ -3,6 +3,7 @@ package shipreq.webapp.base.protocol
 import shipreq.base.test.BaseTestUtil._
 import shipreq.base.util.BinaryData
 import shipreq.webapp.base.protocol.binary.SafePickler
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 import shipreq.webapp.base.test.BinaryTestUtil._
 import sourcecode.Line
 import utest._
@@ -63,10 +64,10 @@ object SafePicklerTest extends TestSuite {
       }
 
     val safePicklerv10: SafePickler[Data] =
-      SafePickler.of(Version.v1(0), _ => picklerv10).withMagicNumbers(123, 456)
+      picklerv10.asV1(0).withMagicNumbers(123, 456)
 
     val safePicklerv11: SafePickler[Data] =
-      SafePickler.of(Version.v1(1), _ => picklerv11).withMagicNumbers(123, 456)
+      picklerv11.asVersion(v11).withMagicNumbers(123, 456)
 
     def modBin(b: BinaryData, f: Array[Byte] => Array[Byte]): BinaryData =
       BinaryData.unsafeFromArray(f(b.toNewArray))
@@ -80,7 +81,7 @@ object SafePicklerTest extends TestSuite {
           inner.embeddedRead
         }
       }
-      SafePickler.of(Version.fromInts(4, 4), _ => p).withMagicNumbers(0x67230F4E, 0xA0B18F5D)
+      p.asVersion(Version.fromInts(4, 4)).withMagicNumbers(0x67230F4E, 0xA0B18F5D)
     }
 
     def assertDecodeFailure(p: SafePickler[_], bin: BinaryData)(pf: PartialFunction[DecodingFailure, Unit])

--- a/Code/webapp-base/shared/src/main/scala/shipreq/webapp/base/protocol/ajax/CommonProtocols.scala
+++ b/Code/webapp-base/shared/src/main/scala/shipreq/webapp/base/protocol/ajax/CommonProtocols.scala
@@ -6,6 +6,7 @@ import shipreq.base.util._
 import shipreq.webapp.base.config.Urls
 import shipreq.webapp.base.data._
 import shipreq.webapp.base.protocol._
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 import shipreq.webapp.base.protocol.binary._
 import shipreq.webapp.base.validation.UserValidators
 import shipreq.webapp.base.validation.lib._
@@ -128,10 +129,10 @@ object CommonProtocols {
         implicitly
 
       implicit val safePicklerRequest: SafePickler[Request] =
-        SafePickler.of(Version.v1(0), _ => picklerRequest).withMagicNumbers(0x8AB0DAD1, 0x38E21961)
+        picklerRequest.asV1(0).withMagicNumbers(0x8AB0DAD1, 0x38E21961)
 
       implicit val safePicklerResponse: SafePickler[Response] =
-        SafePickler.of(Version.v1(0), _ => picklerResponse).withMagicNumbers(0xBAD9BE35, 0xBCACEC71)
+        picklerResponse.asV1(0).withMagicNumbers(0xBAD9BE35, 0xBCACEC71)
 
       defAjax("login")
     }
@@ -191,10 +192,10 @@ object CommonProtocols {
         implicitly
 
       implicit val safePicklerRequest: SafePickler[Request] =
-        SafePickler.of(Version.v1(0), _ => picklerRequest).withMagicNumbers(0xBFA2418E, 0xF5D4C77E)
+        picklerRequest.asV1(0).withMagicNumbers(0xBFA2418E, 0xF5D4C77E)
 
       implicit val safePicklerResponse: SafePickler[Response] =
-        SafePickler.of(Version.v1(0), _ => picklerResponse).withMagicNumbers(0x640CFE5C, 0x9DD455FA)
+        picklerResponse.asV1(0).withMagicNumbers(0x640CFE5C, 0x9DD455FA)
 
       defAjax("error")
     }
@@ -244,10 +245,10 @@ object CommonProtocols {
         implicitly
 
       implicit val safePicklerRequest: SafePickler[Request] =
-        SafePickler.of(Version.v1(0), _ => picklerRequest).withMagicNumbers(0xC8EF5F9E, 0x35FCD3C3)
+        picklerRequest.asV1(1).withMagicNumbers(0xC8EF5F9E, 0x35FCD3C3)
 
       implicit val safePicklerResponse: SafePickler[Response] =
-        SafePickler.of(Version.v1(0), _ => picklerResponse).withMagicNumbers(0x69420882, 0x48AFA035)
+        picklerResponse.asV1(1).withMagicNumbers(0x69420882, 0x48AFA035)
 
       defAjax("feedback")
     }

--- a/Code/webapp-base/shared/src/main/scala/shipreq/webapp/base/protocol/binary/SafePickler.scala
+++ b/Code/webapp-base/shared/src/main/scala/shipreq/webapp/base/protocol/binary/SafePickler.scala
@@ -15,7 +15,7 @@ import shipreq.webapp.base.protocol.Version.ordering.mkOrderingOps
 final case class SafePickler[A](header : Option[MagicNumber],
                                 footer : Option[MagicNumber],
                                 version: Version,
-                                body   : Version.Minor => Pickler[A]) {
+                                body   : Pickler[A]) {
 
   type Data = A
 
@@ -30,7 +30,7 @@ final case class SafePickler[A](header : Option[MagicNumber],
     copy(footer = Some(MagicNumber(footer)))
 
   def map[B](f: Pickler[A] => Pickler[B]): SafePickler[B] =
-    copy(body = v => f(body(v)))
+    copy(body = f(body))
 
   private val picklerHeader  = header.map(pickleMagicNumber(version, _))
   private val picklerFooter  = footer.map(pickleMagicNumber(version, _))
@@ -42,7 +42,7 @@ final case class SafePickler[A](header : Option[MagicNumber],
       override def pickle(a: A)(implicit state: PickleState): Unit = {
         picklerHeader.foreach(_.pickle(()))
         picklerVersion.pickle(version)
-        body(version.minor).pickle(a)
+        body.pickle(a)
         picklerFooter.foreach(_.pickle(()))
       }
 
@@ -52,7 +52,7 @@ final case class SafePickler[A](header : Option[MagicNumber],
         if (v.major !=* version.major)
           throw DecodingFailure.UnsupportedMajorVer(localVer = version, actual = v)
         try {
-          val a = body(v.minor).unpickle
+          val a = body.unpickle
           picklerFooter.foreach(_.unpickle)
           a
         } catch {
@@ -196,8 +196,14 @@ object SafePickler {
       }
     }
 
-  def of[A](v: Version, body: Version.Minor => Pickler[A]): SafePickler[A] =
-    SafePickler(None, None, v, body)
+  object ConstructionHelperImplicits {
+    implicit class SafePickler_PicklerExt[A](private val self: Pickler[A]) extends AnyVal {
+      @inline def asVersion(major: Int, minor: Int): SafePickler[A] = asVersion(Version.fromInts(major, minor))
+      def asVersion(v: Version): SafePickler[A] = SafePickler(None, None, v, self)
+      def asV1(minorVer: Int)  : SafePickler[A] = asVersion(Version.v1(minorVer))
+      def asV2(minorVer: Int)  : SafePickler[A] = asVersion(Version.v2(minorVer))
+    }
+  }
 }
 
 final case class MagicNumber(value: Int) {

--- a/Code/webapp-base/shared/src/main/scala/shipreq/webapp/base/protocol/websocket/WebSocketShared.scala
+++ b/Code/webapp-base/shared/src/main/scala/shipreq/webapp/base/protocol/websocket/WebSocketShared.scala
@@ -4,6 +4,7 @@ import boopickle.DefaultBasic._
 import shipreq.base.util.Util
 import shipreq.webapp.base.protocol._
 import shipreq.webapp.base.protocol.binary.SafePickler
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 
 object WebSocketShared {
 
@@ -189,8 +190,6 @@ object WebSocketShared {
         }
       }
 
-    val safePickler = SafePickler.of(Version.v1(0), _ => pickler)
-
-    Protocol(safePickler)
+    Protocol(pickler.asV1(0))
   }
 }

--- a/Code/webapp-client-public/shared/src/main/scala/shipreq/webapp/client/public/PublicSpaProtocols.scala
+++ b/Code/webapp-client-public/shared/src/main/scala/shipreq/webapp/client/public/PublicSpaProtocols.scala
@@ -6,6 +6,7 @@ import shipreq.base.util._
 import shipreq.webapp.base.config.Urls
 import shipreq.webapp.base.data._
 import shipreq.webapp.base.protocol._
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 import shipreq.webapp.base.protocol.binary._
 import shipreq.webapp.base.util.TextMod
 import shipreq.webapp.base.validation.UserValidators
@@ -86,10 +87,10 @@ object PublicSpaProtocols {
         implicitly
 
       implicit val safePicklerRequest: SafePickler[Request] =
-        SafePickler.of(Version.v1(0), _ => picklerRequest).withMagicNumbers(0xB5AE4CF5, 0x228FA2F2)
+        picklerRequest.asV1(0).withMagicNumbers(0xB5AE4CF5, 0x228FA2F2)
 
       implicit val safePicklerResponse: SafePickler[Response] =
-        SafePickler.of(Version.v1(0), _ => picklerResponse).withMagicNumbers(0x7CD703D9, 0xB2C6D5E3)
+        picklerResponse.asV1(0).withMagicNumbers(0x7CD703D9, 0xB2C6D5E3)
 
       defAjax[Request, Response]("lp")
     }
@@ -107,10 +108,10 @@ object PublicSpaProtocols {
       val picklerResponse: Pickler[Response] = implicitly
 
       implicit val safePicklerRequest: SafePickler[Request] =
-        SafePickler.of(Version.v1(0), _ => picklerRequest).withMagicNumbers(0x89827590, 0x8858F858)
+        picklerRequest.asV1(0).withMagicNumbers(0x89827590, 0x8858F858)
 
       implicit val safePicklerResponse: SafePickler[Response] =
-        SafePickler.of(Version.v1(0), _ => picklerResponse).withMagicNumbers(0x0FCE3232, 0x713A4224)
+        picklerResponse.asV1(0).withMagicNumbers(0x0FCE3232, 0x713A4224)
 
       defAjax("reg1")
     }
@@ -198,10 +199,10 @@ object PublicSpaProtocols {
         pickleDisj
 
       implicit val safePicklerRequest: SafePickler[Request] =
-        SafePickler.of(Version.v1(0), _ => picklerRequest).withMagicNumbers(0x456C4A18, 0x74601B38)
+        picklerRequest.asV1(0).withMagicNumbers(0x456C4A18, 0x74601B38)
 
       implicit val safePicklerResponse: SafePickler[Response] =
-        SafePickler.of(Version.v1(0), _ => picklerResponse).withMagicNumbers(0x9FE45912, 0x6FDDAE09)
+        picklerResponse.asV1(0).withMagicNumbers(0x9FE45912, 0x6FDDAE09)
 
       defAjax("reg2")
     }
@@ -219,10 +220,10 @@ object PublicSpaProtocols {
       val picklerResponse: Pickler[Response] = implicitly
 
       implicit val safePicklerRequest: SafePickler[Request] =
-        SafePickler.of(Version.v1(0), _ => picklerRequest).withMagicNumbers(0x1EFE85AA, 0x43067CC7)
+        picklerRequest.asV1(0).withMagicNumbers(0x1EFE85AA, 0x43067CC7)
 
       implicit val safePicklerResponse: SafePickler[Response] =
-        SafePickler.of(Version.v1(0), _ => picklerResponse).withMagicNumbers(0xFEF9FB89, 0x318614CF)
+        picklerResponse.asV1(0).withMagicNumbers(0xFEF9FB89, 0x318614CF)
 
       defAjax("rp1")
     }
@@ -280,10 +281,10 @@ object PublicSpaProtocols {
         pickleDisj
 
       implicit val safePicklerRequest: SafePickler[Request] =
-        SafePickler.of(Version.v1(0), _ => picklerRequest).withMagicNumbers(0x024A43EE, 0x63AE6C82)
+        picklerRequest.asV1(0).withMagicNumbers(0x024A43EE, 0x63AE6C82)
 
       implicit val safePicklerResponse: SafePickler[Response] =
-        SafePickler.of(Version.v1(0), _ => picklerResponse).withMagicNumbers(0xB9CB8212, 0xDA4601AD)
+        picklerResponse.asV1(0).withMagicNumbers(0xB9CB8212, 0xDA4601AD)
 
       defAjax("rp2")
     }

--- a/Code/webapp-client-ww-api/src/main/scala/shipreq/webapp/client/ww/api/WebWorkerCmd.scala
+++ b/Code/webapp-client-ww-api/src/main/scala/shipreq/webapp/client/ww/api/WebWorkerCmd.scala
@@ -69,10 +69,8 @@ object WebWorkerCmd {
       i => Option.when(i > 0)(EventOrd.Latest(i)))(
       _.fold(0)(_.value))
 
-  implicit val picklerUpdateProject: Pickler[UpdateProject] = {
-    implicit val x = picklerProjectOrEvents(latestMinorVersion)
+  implicit val picklerUpdateProject: Pickler[UpdateProject] =
     transformPickler(UpdateProject.apply)(_.data)
-  }
 
   implicit val picklerErrorMsgOrSvg: Pickler[ErrorMsg \/ Svg] =
     pickleDisj

--- a/Code/webapp-member-test/js/src/test/scala/shipreq/webapp/member/protocol/indexeddb/IndexedDbTest.scala
+++ b/Code/webapp-member-test/js/src/test/scala/shipreq/webapp/member/protocol/indexeddb/IndexedDbTest.scala
@@ -2,7 +2,6 @@ package shipreq.webapp.member.protocol.indexeddb
 
 import japgolly.scalajs.react._
 import shipreq.base.test.Node.asyncTest
-import shipreq.webapp.base.protocol.Version
 import shipreq.webapp.base.protocol.binary.SafePickler
 import shipreq.webapp.member.project.data.Project
 import shipreq.webapp.member.protocol.binary.{BinaryFormat, Compression}
@@ -58,11 +57,12 @@ object IndexedDbTest extends TestSuite {
       import shipreq.webapp.member.project.protocol.binary.Latest.picklerProject
       import SampleProject8.{project => project1}
       import SampleProject5.{project => project2}
+      import SafePickler.ConstructionHelperImplicits._
       import TestEncryption.UnsafeTypes._
       import ValueCodec.Async.binary
 
       implicit val safePicklerProject: SafePickler[Project] =
-        SafePickler.of(Version.v1(0), _ => picklerProject).withMagicNumbers(0x89827590, 0x8858F858)
+        picklerProject.asV1(0).withMagicNumbers(0x89827590, 0x8858F858)
 
       val zip3 = Compression(3, addHeaders = false)
       val zip9 = Compression(9, addHeaders = false)

--- a/Code/webapp-member-test/js/src/test/scala/shipreq/webapp/member/protocol/websocket/WebSocketClientTester.scala
+++ b/Code/webapp-member-test/js/src/test/scala/shipreq/webapp/member/protocol/websocket/WebSocketClientTester.scala
@@ -9,6 +9,7 @@ import shipreq.base.util._
 import shipreq.webapp.base.lib.LoggerJs
 import shipreq.webapp.base.protocol._
 import shipreq.webapp.base.protocol.binary.SafePickler
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 import shipreq.webapp.base.protocol.websocket.WebSocket.ReadyState
 import shipreq.webapp.base.protocol.websocket.WebSocketShared.ReqId
 import shipreq.webapp.base.protocol.websocket._
@@ -34,9 +35,9 @@ object WebSocketClientTester {
     override type ReqId  = WebSocketShared.ReqId
     override type ReqRes = Protocol.RequestResponse.Simple[SafePickler, ReqMsg, ResMsg]
     override val url     = Url.Relative("/x")
-    override val req     = Protocol(SafePickler.of(Version.v1(0), _ => transformPickler(ReqMsg.apply)(_.msg)))
-    override val push    = Protocol(SafePickler.of(Version.v1(0), _ => transformPickler(PushMsg.apply)(_.msg)))
-    val res              = Protocol(SafePickler.of(Version.v1(0), _ => transformPickler(ResMsg.apply)(_.msg)))
+    override val req     = Protocol(transformPickler(ReqMsg.apply)(_.msg).asV1(0))
+    override val push    = Protocol(transformPickler(PushMsg.apply)(_.msg).asV1(0))
+    val res              = Protocol(transformPickler(ResMsg.apply)(_.msg).asV1(0))
     val ReqRes: ReqRes   = Protocol.RequestResponse.simple(res)
   }
 

--- a/Code/webapp-member-test/shared/src/test/scala/shipreq/webapp/member/protocol/ajax/HomeSpaProtocolsTest.scala
+++ b/Code/webapp-member-test/shared/src/test/scala/shipreq/webapp/member/protocol/ajax/HomeSpaProtocolsTest.scala
@@ -41,7 +41,7 @@ object HomeSpaProtocolsTest extends TestSuite {
         }
 
         "v2.1" - {
-          val bin    = BinaryData.fromHex("C3407BB2020108434B62785064724901092432686C557766232102816180F0815FE0D93ADB5B362FC92DE0EB3ADB5BE63E331F0101E7704A00")
+          val bin    = BinaryData.fromHex("C3407BB20201D5F5B6070108434B62785064724901092432686C557766232102816180F0815FE0D93ADB5B362FC92DE0EB3ADB5BE63E331F0101E7704A00")
           val expect = ProjectMetaData(Obfuscated("CKbxPdrI"), "$2hlUwf#!", Some(ProjectRole.Admin), 2, 353, 240, 351, Instant.ofEpochSecond(1541094105L, 768159542), Instant.ofEpochSecond(1541094123L, 523452134), None, Live)
           assertDecodeOk(codec)(bin, expect)
         }

--- a/Code/webapp-member-test/shared/src/test/scala/shipreq/webapp/member/protocol/entrypoint/ProjectSpaEntryPointTest.scala
+++ b/Code/webapp-member-test/shared/src/test/scala/shipreq/webapp/member/protocol/entrypoint/ProjectSpaEntryPointTest.scala
@@ -2,8 +2,7 @@ package shipreq.webapp.member.protocol.entrypoint
 
 import cats.Eq
 import japgolly.microlibs.cats_ext.CatsMacros
-import shipreq.webapp.base.protocol.Version
-import shipreq.webapp.base.protocol.binary.SafePickler
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 import shipreq.webapp.base.test.BinaryTestUtil._
 import shipreq.webapp.member.test.project.RandomData
 import utest._
@@ -14,9 +13,6 @@ object ProjectSpaEntryPointTest extends TestSuite {
     CatsMacros.deriveEq
 
   override def tests = Tests {
-    "roundTrip" - {
-      val protocol = SafePickler.of(Version.v1(0), _ => ProjectSpaEntryPoint.picklerInitData)
-      propTestRoundTrip(protocol)(RandomData.routines.projectSpaInitPageData)
-    }
+    "roundTrip" - propTestRoundTrip(ProjectSpaEntryPoint.picklerInitData.asV1(0))(RandomData.routines.projectSpaInitPageData)
   }
 }

--- a/Code/webapp-member/js/src/main/scala/shipreq/webapp/member/project/storage/IndexedDbStorage.scala
+++ b/Code/webapp-member/js/src/main/scala/shipreq/webapp/member/project/storage/IndexedDbStorage.scala
@@ -127,6 +127,7 @@ object IndexedDbStorage {
   // ===================================================================================================================
 
   private[IndexedDbStorage] final class Schema(ctx: ClientSideStorage.Context, encryption: Encryption, dbNamePrefix: String) {
+    import SafePickler.ConstructionHelperImplicits._
 
     val dbName = IndexedDb.DatabaseName(dbNamePrefix + ctx.namespace)
     val dbVer  = 1
@@ -140,7 +141,9 @@ object IndexedDbStorage {
       import shipreq.webapp.member.project.protocol.binary.v2.Rev1.picklerProject
 
       implicit val pickler: SafePickler[Project] =
-        SafePickler.of(ver, picklerProject).withMagicNumbers(0x8CF0655B, 0x5A8218EB)
+        picklerProject
+          .asVersion(ver)
+          .withMagicNumbers(0x8CF0655B, 0x5A8218EB)
 
       val format: BinaryFormat[Project] =
         BinaryFormat.versioned(

--- a/Code/webapp-member/js/src/main/scala/shipreq/webapp/member/project/storage/WebStorage.scala
+++ b/Code/webapp-member/js/src/main/scala/shipreq/webapp/member/project/storage/WebStorage.scala
@@ -1,6 +1,5 @@
 package shipreq.webapp.member.project.storage
 
-import boopickle.Pickler
 import japgolly.scalajs.react.{AsyncCallback, CallbackTo}
 import shipreq.webapp.base.data.ProjectCreator
 import shipreq.webapp.base.protocol.Version
@@ -69,6 +68,7 @@ final class WebStorage(ws        : AbstractWebStorage,
 object WebStorage {
 
   private[WebStorage] final class Protocols(creator: ProjectCreator, encryption: Encryption) {
+    import SafePickler.ConstructionHelperImplicits._
 
     object projectLibrary {
 
@@ -77,12 +77,11 @@ object WebStorage {
 
       val cache = CacheJs(creator)
 
-      def picklerProjectLibrary(v: Version.Minor): Pickler[ProjectLibrary] =
-        picklerProject(v)
-          .xmap(ProjectLibrary.init(creator, _, cache))(_.latest)
-
       implicit val pickler: SafePickler[ProjectLibrary] =
-        SafePickler.of(ver, picklerProjectLibrary).withMagicNumbers(0x7F19E183, 0x3365F95A)
+        picklerProject
+          .xmap(ProjectLibrary.init(creator, _, cache))(_.latest)
+          .asVersion(ver)
+          .withMagicNumbers(0x7F19E183, 0x3365F95A)
 
       val format: BinaryFormat[ProjectLibrary] =
         BinaryFormat.versioned(

--- a/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/project/protocol/binary/Latest.scala
+++ b/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/project/protocol/binary/Latest.scala
@@ -7,7 +7,7 @@ package shipreq.webapp.member.project.protocol.binary
 object Latest {
 
   @inline implicit def picklerEvent                    = v2.Rev1.picklerEvent
-  @inline implicit def picklerProject                  = v2.Rev1.picklerProject(v2.Rev1.latestMinorVersion)
+  @inline implicit def picklerProject                  = v2.Rev1.picklerProject
   @inline implicit def picklerVerifiedEvent            = v2.Rev1.picklerVerifiedEvent
   @inline implicit def picklerVerifiedEventSeq         = v2.Rev1.picklerVerifiedEventSeq
   @inline implicit def picklerVerifiedEventNonEmptySeq = v2.Rev1.picklerVerifiedEventNonEmptySeq

--- a/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/project/protocol/binary/v2/Rev1.scala
+++ b/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/project/protocol/binary/v2/Rev1.scala
@@ -3,8 +3,7 @@ package shipreq.webapp.member.project.protocol.binary.v2
 import java.time.Instant
 import shipreq.base.util.ErrorMsg
 import shipreq.webapp.base.data._
-import shipreq.webapp.base.protocol.Version
-import shipreq.webapp.member.project.data._
+import shipreq.webapp.member.project.data.{Live => _, _}
 import shipreq.webapp.member.project.event._
 import shipreq.webapp.member.project.text.Text.DeletionReason
 
@@ -22,12 +21,11 @@ object Rev1 {
   import Rev0._
   import AtomPicklers.instances._
 
-  val latestMinorVersion = Version.Minor(1)
-
-  def picklerProject(v: Version.Minor): Pickler[Project] =
+  // + deletionReason: Option[DeletionReason.OptionalText]
+  implicit lazy val picklerProject: Pickler[Project] =
     new Pickler[Project] {
       override def pickle(p: Project)(implicit state: PickleState): Unit = {
-        assert(v ==* latestMinorVersion)
+        writeVersion(1)
         state.pickle(p.name)
         state.pickle(p.config)
         state.pickle(p.content)
@@ -38,18 +36,35 @@ object Rev1 {
         state.pickle(p.history)
         state.pickle(p.idCeilings)
       }
-      override def unpickle(implicit state: UnpickleState): Project = {
-        val name           = state.unpickle[Project.Name]
-        val config         = state.unpickle[ProjectConfig]
-        val content        = state.unpickle[ProjectContent]
-        val manualIssues   = state.unpickle[ManualIssues]
-        val savedViews     = state.unpickle[savedview.SavedViews.Optional]
-        val access         = state.unpickle[ProjectAccess]
-        val deletionReason = if (v.value >= 1) state.unpickle[Option[DeletionReason.OptionalText]] else None
-        val history        = state.unpickle[ProjectEvents]
-        val idCeilings     = state.unpickle[IdCeilings]
-        Project(name, config, content, manualIssues, savedViews, access, deletionReason, history, idCeilings)
-      }
+      override def unpickle(implicit state: UnpickleState): Project =
+        readByVersion(1) {
+
+          // v1.0
+          case 0 =>
+            val name           = state.unpickle[Project.Name]
+            val config         = state.unpickle[ProjectConfig]
+            val content        = state.unpickle[ProjectContent]
+            val manualIssues   = state.unpickle[ManualIssues]
+            val savedViews     = state.unpickle[savedview.SavedViews.Optional]
+            val access         = state.unpickle[ProjectAccess]
+            val deletionReason = Option.empty[DeletionReason.OptionalText]
+            val history        = state.unpickle[ProjectEvents]
+            val idCeilings     = state.unpickle[IdCeilings]
+            Project(name, config, content, manualIssues, savedViews, access, deletionReason, history, idCeilings)
+
+          // v1.1
+          case 1 =>
+            val name           = state.unpickle[Project.Name]
+            val config         = state.unpickle[ProjectConfig]
+            val content        = state.unpickle[ProjectContent]
+            val manualIssues   = state.unpickle[ManualIssues]
+            val savedViews     = state.unpickle[savedview.SavedViews.Optional]
+            val access         = state.unpickle[ProjectAccess]
+            val deletionReason = state.unpickle[Option[DeletionReason.OptionalText]]
+            val history        = state.unpickle[ProjectEvents]
+            val idCeilings     = state.unpickle[IdCeilings]
+            Project(name, config, content, manualIssues, savedViews, access, deletionReason, history, idCeilings)
+        }
     }
 
   private[binary] implicit lazy val picklerEventProjectDelete: Pickler[Event.ProjectDelete] =
@@ -326,15 +341,14 @@ object Rev1 {
   implicit lazy val picklerProjectEvents: Pickler[ProjectEvents] =
     transformPickler(ProjectEvents.apply)(_.events)
 
-  def picklerProjectOrEvents(projectVer: Version.Minor): Pickler[Project \/ VerifiedEvent.Seq] = {
-    implicit val p = picklerProject(projectVer)
+  implicit lazy val picklerProjectOrEvents: Pickler[Project \/ VerifiedEvent.Seq] =
     pickleDisj
-  }
 
   // New field: .live
   implicit lazy val picklerProjectMetaData: Pickler[ProjectMetaData] =
     new Pickler[ProjectMetaData] {
       override def pickle(a: ProjectMetaData)(implicit state: PickleState): Unit = {
+        writeVersion(1)
         state.pickle(a.id)
         state.pickle(a.role)
         state.pickle(a.name)
@@ -347,31 +361,60 @@ object Rev1 {
         state.pickle(a.lastUpdatedAt)
         state.pickle(a.live)
       }
-      override def unpickle(implicit state: UnpickleState): ProjectMetaData = {
-        val id            = state.unpickle[ProjectId.Public]
-        val role          = state.unpickle[Option[ProjectRole]]
-        val name          = state.unpickle[Project.Name]
-        val eventsInit    = state.unpickle[Int]
-        val eventsTotal   = state.unpickle[Int]
-        val reqsLive      = state.unpickle[Int]
-        val reqsTotal     = state.unpickle[Int]
-        val createdAt     = state.unpickle[Instant]
-        val accessedAt    = state.unpickle[Instant]
-        val lastUpdatedAt = state.unpickle[Option[Instant]]
-        val live          = state.unpickle[Live]
-        ProjectMetaData(
-          id            = id,
-          role          = role,
-          name          = name,
-          eventsInit    = eventsInit,
-          eventsTotal   = eventsTotal,
-          reqsLive      = reqsLive,
-          reqsTotal     = reqsTotal,
-          createdAt     = createdAt,
-          accessedAt    = accessedAt,
-          lastUpdatedAt = lastUpdatedAt,
-          live          = live)
-      }
+      override def unpickle(implicit state: UnpickleState): ProjectMetaData =
+        readByVersion(1) {
+
+          // v1.0
+          case 0 =>
+            val id            = state.unpickle[ProjectId.Public]
+            val role          = state.unpickle[Option[ProjectRole]]
+            val name          = state.unpickle[Project.Name]
+            val eventsInit    = state.unpickle[Int]
+            val eventsTotal   = state.unpickle[Int]
+            val reqsLive      = state.unpickle[Int]
+            val reqsTotal     = state.unpickle[Int]
+            val createdAt     = state.unpickle[Instant]
+            val accessedAt    = state.unpickle[Instant]
+            val lastUpdatedAt = state.unpickle[Option[Instant]]
+            ProjectMetaData(
+              id            = id,
+              role          = role,
+              name          = name,
+              eventsInit    = eventsInit,
+              eventsTotal   = eventsTotal,
+              reqsLive      = reqsLive,
+              reqsTotal     = reqsTotal,
+              createdAt     = createdAt,
+              accessedAt    = accessedAt,
+              lastUpdatedAt = lastUpdatedAt,
+              live          = Live)
+
+          // v1.1
+          case 1 =>
+            val id            = state.unpickle[ProjectId.Public]
+            val role          = state.unpickle[Option[ProjectRole]]
+            val name          = state.unpickle[Project.Name]
+            val eventsInit    = state.unpickle[Int]
+            val eventsTotal   = state.unpickle[Int]
+            val reqsLive      = state.unpickle[Int]
+            val reqsTotal     = state.unpickle[Int]
+            val createdAt     = state.unpickle[Instant]
+            val accessedAt    = state.unpickle[Instant]
+            val lastUpdatedAt = state.unpickle[Option[Instant]]
+            val live          = state.unpickle[Live]
+            ProjectMetaData(
+              id            = id,
+              role          = role,
+              name          = name,
+              eventsInit    = eventsInit,
+              eventsTotal   = eventsTotal,
+              reqsLive      = reqsLive,
+              reqsTotal     = reqsTotal,
+              createdAt     = createdAt,
+              accessedAt    = accessedAt,
+              lastUpdatedAt = lastUpdatedAt,
+              live          = live)
+        }
     }
 
 }

--- a/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/project/protocol/websocket/ProjectSpaProtocols.scala
+++ b/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/project/protocol/websocket/ProjectSpaProtocols.scala
@@ -9,6 +9,7 @@ import shipreq.webapp.base.config.Urls
 import shipreq.webapp.base.data._
 import shipreq.webapp.base.protocol._
 import shipreq.webapp.base.protocol.binary.SafePickler
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 import shipreq.webapp.base.protocol.websocket.WebSocketShared
 import shipreq.webapp.member.project.data._
 import shipreq.webapp.member.project.event.{EventOrd, VerifiedEvent}
@@ -130,7 +131,8 @@ object ProjectSpaProtocols {
           }
         }
 
-      SafePickler.of(wsrrVersion, _ => pickler)
+      pickler
+        .asVersion(wsrrVersion)
         .withMagicNumbers(0x1DB44559, 0x53562938)
     }
 
@@ -160,9 +162,8 @@ object ProjectSpaProtocols {
       @inline private implicit def picklerSupp = picklerSupplimentary_v10
       @inline private implicit def picklerStateUpdate = picklerStateUpdate_v11
 
-      private def picklerInitAppData(v: Version.Minor): Pickler[InitAppData] =
+      private implicit val picklerInitAppData: Pickler[InitAppData] =
         new Pickler[InitAppData] {
-          private implicit val picklerProjectV = picklerProject(v)
           override def pickle(a: InitAppData)(implicit state: PickleState): Unit = {
             state.pickle(a.projectData)
             state.pickle(a.projectMetaData)
@@ -176,10 +177,8 @@ object ProjectSpaProtocols {
           }
         }
 
-      private def picklerInitAppRes(v: Version.Minor): Pickler[ErrorMsg \/ InitAppData] = {
-        implicit val x = picklerInitAppData(v)
+      private implicit val picklerInitAppRes: Pickler[ErrorMsg \/ InitAppData] =
         pickleDisj
-      }
 
       private implicit val picklerEventResult: Pickler[WsReqRes.EventResult] =
         pickleDisj
@@ -189,16 +188,22 @@ object ProjectSpaProtocols {
       // We're keeping a magic footer just in case.
 
       implicit val safePicklerUnit: SafePickler[Unit] =
-        SafePickler.of(Version.v1(0), _ => unitPickler) // no magic numbers because no data
+        unitPickler.asV1(0) // no magic numbers because no data
 
       implicit val safePicklerInitAppRes: SafePickler[ErrorMsg \/ InitAppData] =
-        SafePickler.of(responseVersion, picklerInitAppRes).withMagicNumberFooter(0x8819303B)
+        picklerInitAppRes
+          .asVersion(responseVersion)
+          .withMagicNumberFooter(0x8819303B)
 
       implicit val safePicklerEventResult: SafePickler[WsReqRes.EventResult] =
-        SafePickler.of(responseVersion, _ => picklerEventResult).withMagicNumberFooter(0x86DA8677)
+        picklerEventResult
+          .asVersion(responseVersion)
+          .withMagicNumberFooter(0x86DA8677)
 
       implicit val safePicklerStateUpdate: SafePickler[StateUpdate] =
-        SafePickler.of(responseVersion, _ => picklerStateUpdate).withMagicNumberFooter(0x8473B8AD)
+        picklerStateUpdate
+          .asVersion(responseVersion)
+          .withMagicNumberFooter(0x8473B8AD)
     }
 
     object Push {
@@ -209,7 +214,9 @@ object ProjectSpaProtocols {
         picklerStateUpdate
 
       val safePickler: SafePickler[WebSocket.Push] =
-        SafePickler.of(version, _ => pickler).withMagicNumberFooter(0x06F60C06)
+        pickler
+          .asVersion(version)
+          .withMagicNumberFooter(0x06F60C06)
     }
   }
 

--- a/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/protocol/ajax/HomeSpaProtocols.scala
+++ b/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/protocol/ajax/HomeSpaProtocols.scala
@@ -2,7 +2,8 @@ package shipreq.webapp.member.protocol.ajax
 
 import boopickle.DefaultBasic._
 import shipreq.webapp.base.config.Urls
-import shipreq.webapp.base.protocol._
+import shipreq.webapp.base.protocol.Protocol
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 import shipreq.webapp.base.protocol.binary._
 import shipreq.webapp.member.project.data._
 
@@ -28,10 +29,10 @@ object HomeSpaProtocols {
       val picklerResponse: Pickler[Response] = implicitly
 
       implicit val safePicklerRequest: SafePickler[Request] =
-        SafePickler.of(Version.v1(0), _ => picklerRequest).withMagicNumbers(0x42A63E36, 0x0C1B2566)
+        picklerRequest.asV1(0).withMagicNumbers(0x42A63E36, 0x0C1B2566)
 
       implicit val safePicklerResponse: SafePickler[Response] =
-        SafePickler.of(Version.v2(1), _ => picklerResponse).withMagicNumbers(0xB27B40C3, 0x004A70E7)
+        picklerResponse.asV2(1).withMagicNumbers(0xB27B40C3, 0x004A70E7)
 
       defAjax[Request, Response]("cp")
     }

--- a/Code/webapp-server-logic/jvm/src/main/scala/shipreq/webapp/server/logic/protocol/RedisProtocol.scala
+++ b/Code/webapp-server-logic/jvm/src/main/scala/shipreq/webapp/server/logic/protocol/RedisProtocol.scala
@@ -2,6 +2,7 @@ package shipreq.webapp.server.logic.protocol
 
 import shipreq.webapp.base.protocol.Version
 import shipreq.webapp.base.protocol.binary.SafePickler
+import shipreq.webapp.base.protocol.binary.SafePickler.ConstructionHelperImplicits._
 import shipreq.webapp.member.project.data.Project
 import shipreq.webapp.member.project.event.{EventOrd, VerifiedEvent}
 import shipreq.webapp.server.logic.algebra.Redis.ProjectSnapshot
@@ -15,9 +16,8 @@ object RedisProtocol {
     import shipreq.webapp.member.project.protocol.binary.v1.PostEvents.picklerEventOrdLatest
     import shipreq.webapp.member.project.protocol.binary.v2.Rev1.picklerProject
 
-    def pickler(v: Version.Minor): Pickler[ProjectSnapshot] =
+    val pickler: Pickler[ProjectSnapshot] =
       new Pickler[ProjectSnapshot] {
-        private implicit val p = picklerProject(v)
         override def pickle(a: ProjectSnapshot)(implicit state: PickleState): Unit = {
           state.pickle(a.project)
           state.pickle(a.ord)
@@ -29,7 +29,8 @@ object RedisProtocol {
         }
       }
 
-    SafePickler.of(ver, pickler)
+    pickler
+      .asVersion(ver)
       .withMagicNumbers(0x713D305C, 0xB72AC2DE)
   }
 
@@ -41,7 +42,7 @@ object RedisProtocol {
 
     // - no magic numbers - overhead to high proportional to the event size, too frequent
     // - picklerVerifiedEvent is already backwards-compatible - no need to inspect version
-    SafePickler.of(ver, _ => picklerVerifiedEvent)
+    picklerVerifiedEvent.asVersion(ver)
   }
 
 }

--- a/Code/webapp-server-logic/jvm/src/test/scala/shipreq/webapp/server/logic/protocol/RedisProtocolTest.scala
+++ b/Code/webapp-server-logic/jvm/src/test/scala/shipreq/webapp/server/logic/protocol/RedisProtocolTest.scala
@@ -94,7 +94,7 @@ object RedisProtocolTest extends TestSuite {
 
       "v2.1" - {
         "empty" - {
-          val bin    = BinaryData.fromHex("5C303D710201000000000523494E454700000000000000000000000001010101010100000000000000000000DEC22AB7")
+          val bin    = BinaryData.fromHex("5C303D710201D5F5B60701000000000523494E454700000000000000000000000001010101010100000000000000000000DEC22AB7")
           val expect = ProjectSnapshot(emptyProject1, 0)
           assertDecodeOk(codec)(bin, expect)
         }


### PR DESCRIPTION
Reverts changes made in fc575a766b60c0e93374449a584e1e484c0d0453

`writeVersion` and `readByVersion` are what's supposed to be used for backwards-compatible codec evolution.
