### PR TITLE
Bugfix: `field:Detail=notBlank` filter now works again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * Automatically update the Issues page filter when the project changes
 * Bugfix: preview buttons weren't working from editors in the Issues page
+* Bugfix: `field:Detail=notBlank` filter now works again
 * Links in rich text now open in new tabs
 
 

--- a/Code/webapp-member-test/shared/src/test/scala/shipreq/webapp/member/project/filter/ValidFilterTest.scala
+++ b/Code/webapp-member-test/shared/src/test/scala/shipreq/webapp/member/project/filter/ValidFilterTest.scala
@@ -49,6 +49,7 @@ object ValidFilterTest extends TestSuite {
         import shipreq.webapp.member.test.project.UnsafeTypes.{autoHashRefKey => _, _}
         def posNA =   "You can't specify values"
         "exact"      - assertTranslation(PF.fieldProp("Description", Attr("blank")))(VF.fieldProp(\/-(descField), Blank))
+        "notBlank"   - assertTranslation(PF.fieldProp("Description", Attr("notBlank")))(VF.fieldProp(\/-(descField), NotBlank))
         "caseWrong"  - assertTranslation(PF.fieldProp("descriPTION", Attr("blank")))(VF.fieldProp(\/-(descField), Blank))
         "title"      - assertTranslation(PF.fieldProp("TITLE", Attr("BLANK")))(VF.fieldProp(-\/(Title), Blank))
         "impField"   - assertTranslation(PF.fieldProp("MF", Attr("BLANK")))(VF.fieldProp(\/-(mfField), Blank))

--- a/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/project/filter/FilterAst.scala
+++ b/Code/webapp-member/shared/src/main/scala/shipreq/webapp/member/project/filter/FilterAst.scala
@@ -60,7 +60,7 @@ object FilterAst {                                                              
       values.whole.map(namesFor(_).next()).mkString(", ")
 
     final lazy val names: Map[String, A] =
-      values.iterator.flatMap(a => namesFor(a).map((_, a))).toMap
+      values.iterator.flatMap(a => namesFor(a).map(s => (s.toLowerCase, a))).toMap
 
     final def apply(n: String): Option[A] =
       names.get(n.toLowerCase)


### PR DESCRIPTION
Fixes #54